### PR TITLE
Add publish and release workflows

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,58 @@
+name: Publish PyPi package
+
+on:
+  workflow_run:
+    workflows: ["Release Workflow"]
+    types:
+      - completed
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    name: Build and publish PyPi package
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Fetch tags
+        run: git fetch --depth=1 --tags
+
+      - name: Get latest tag or set default
+        id: latest_tag
+        run: |
+          TAG=$(git tag -l --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+          if [ -z "$TAG" ]; then
+            TAG="latest"
+          fi
+          echo "::set-output name=tag::$TAG"
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine toml build
+
+      - name: Update pyproject.toml
+        run: |
+          python -c "\
+          import toml; \
+          pyproject = toml.load('pyproject.toml'); \
+          pyproject['project']['version'] = '${{ steps.latest_tag.outputs.tag }}'; \
+          toml.dump(pyproject, open('pyproject.toml', 'w'))"
+
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          python -m build
+          twine upload dist/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,60 @@
+name: Release Workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version (in semantic versioning format, e.g., 1.2.3)'
+        required: true
+        default: '0.0.0'
+        type: string
+      draft:
+        description: 'Create a draft release'
+        required: false
+        default: false
+        type: boolean
+      prerelease:
+        description: 'Mark release as a prerelease'
+        required: false
+        default: false
+        type: boolean
+      releaseMessage:
+        description: 'Release Message'
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+
+      - name: Fetch tags
+        run: git fetch --depth=1 --tags
+
+      - name: Create Git tag
+        run: git tag ${{ github.event.inputs.version }}
+
+      - name: Push Git tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push origin ${{ github.event.inputs.version }}
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          release_name: Release v${{ github.event.inputs.version }}
+          body: ${{ github.event.inputs.releaseMessage }}
+          draft: ${{ github.event.inputs.draft }}
+          prerelease: ${{ github.event.inputs.prerelease }}


### PR DESCRIPTION
PR Summary:
- Added release workflow (add new git tag with given version and push github release)
- Added publish workflow (after new github release triggers the build and publish to pypi.org process)

To be able to use the publish workflow the repository owner needs to add github secrets `PYPI_API_TOKEN` with API token for their pypi.org account (it can be done by registering on https://pypi.org with 2FA and creating new token in settings)